### PR TITLE
Upgrade resolved Swift dependencies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: swift-actions/setup-swift@v3
       with:
-        swift-version: "5.9"
+        swift-version: "5.10.1"
         skip-verify-signature: true
     - uses: actions/checkout@v2
     - name: Build

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
 
@@ -24,8 +25,13 @@ jobs:
         CLARIFAI_GRPC_BASE: ${{ secrets.CLARIFAI_GRPC_BASE }}
         CLARIFAI_API_KEY: ${{ secrets.CLARIFAI_API_KEY }}
       run: swift test -v
+
+  slack-notify:
+    needs: build
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    steps:
     - name: Slack Notify
-      if: ${{ failure() }}
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_ICON: "https://raw.githubusercontent.com/github/explore/2c7e603b797535e5ad8b4beb575ab3b7354666e1/topics/actions/actions.png"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,10 +16,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-    - uses: swift-actions/setup-swift@v3
-      with:
-        swift-version: "5.10.1"
-        skip-verify-signature: true
     - uses: actions/checkout@v2
     - name: Build
       run: swift build -v

--- a/Package.resolved
+++ b/Package.resolved
@@ -20,6 +20,24 @@
         }
       },
       {
+        "package": "swift-asn1",
+        "repositoryURL": "https://github.com/apple/swift-asn1.git",
+        "state": {
+          "branch": null,
+          "revision": "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+          "version": "1.7.0"
+        }
+      },
+      {
+        "package": "swift-async-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-async-algorithms.git",
+        "state": {
+          "branch": null,
+          "revision": "9d349bcc328ac3c31ce40e746b5882742a0d1272",
+          "version": "1.1.3"
+        }
+      },
+      {
         "package": "swift-atomics",
         "repositoryURL": "https://github.com/apple/swift-atomics.git",
         "state": {
@@ -29,12 +47,30 @@
         }
       },
       {
+        "package": "swift-certificates",
+        "repositoryURL": "https://github.com/apple/swift-certificates.git",
+        "state": {
+          "branch": null,
+          "revision": "bde8ca32a096825dfce37467137c903418c1893d",
+          "version": "1.19.1"
+        }
+      },
+      {
         "package": "swift-collections",
         "repositoryURL": "https://github.com/apple/swift-collections.git",
         "state": {
           "branch": null,
           "revision": "03cc312c2c933ed87abace34044a5dff7a3117c1",
           "version": "1.5.0"
+        }
+      },
+      {
+        "package": "swift-crypto",
+        "repositoryURL": "https://github.com/apple/swift-crypto.git",
+        "state": {
+          "branch": null,
+          "revision": "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+          "version": "4.5.0"
         }
       },
       {
@@ -78,8 +114,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "f1f6f772198bee35d99dd145f1513d8581a54f2c",
-          "version": "1.26.0"
+          "revision": "5a48717e29f62cb8326d6d42e46b562ca93847a6",
+          "version": "1.34.0"
         }
       },
       {
@@ -96,8 +132,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "320bd978cceb8e88c125dcbb774943a92f6286e9",
-          "version": "2.25.0"
+          "revision": "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+          "version": "2.37.0"
         }
       },
       {
@@ -125,6 +161,15 @@
           "branch": null,
           "revision": "81558271e243f8f47dfe8e9fdd55f3c2b5413f68",
           "version": "1.37.0"
+        }
+      },
+      {
+        "package": "swift-service-lifecycle",
+        "repositoryURL": "https://github.com/swift-server/swift-service-lifecycle.git",
+        "state": {
+          "branch": null,
+          "revision": "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+          "version": "2.11.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,17 @@
         "repositoryURL": "https://github.com/grpc/grpc-swift.git",
         "state": {
           "branch": null,
-          "revision": "593fe0fe931f7e838969243cd137be48e8055b1d",
-          "version": "1.7.3"
+          "revision": "6a8927df5a91710b414caba4f8a088dead4633db",
+          "version": "1.27.5"
+        }
+      },
+      {
+        "package": "swift-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-algorithms.git",
+        "state": {
+          "branch": null,
+          "revision": "87e50f483c54e6efd60e885f7f5aa946cee68023",
+          "version": "1.2.1"
         }
       },
       {
@@ -15,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-atomics.git",
         "state": {
           "branch": null,
-          "revision": "6c89474e62719ddcc1e9614989fff2f68208fe10",
-          "version": "1.1.0"
+          "revision": "b601256eab081c0f92f059e12818ac1d4f178ff7",
+          "version": "1.3.0"
         }
       },
       {
@@ -24,8 +33,26 @@
         "repositoryURL": "https://github.com/apple/swift-collections.git",
         "state": {
           "branch": null,
-          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
-          "version": "1.0.4"
+          "revision": "03cc312c2c933ed87abace34044a5dff7a3117c1",
+          "version": "1.5.0"
+        }
+      },
+      {
+        "package": "swift-http-structured-headers",
+        "repositoryURL": "https://github.com/apple/swift-http-structured-headers.git",
+        "state": {
+          "branch": null,
+          "revision": "933538faa42c432d385f02e07df0ace7c5ecfc47",
+          "version": "1.7.0"
+        }
+      },
+      {
+        "package": "swift-http-types",
+        "repositoryURL": "https://github.com/apple/swift-http-types.git",
+        "state": {
+          "branch": null,
+          "revision": "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+          "version": "1.5.1"
         }
       },
       {
@@ -33,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "173f567a2dfec11d74588eea82cecea555bdc0bc",
-          "version": "1.4.0"
+          "revision": "5073617dac96330a486245e4c0179cb0a6fd2256",
+          "version": "1.12.0"
         }
       },
       {
@@ -42,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "cf281631ff10ec6111f2761052aa81896a83a007",
-          "version": "2.58.0"
+          "revision": "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+          "version": "2.99.0"
         }
       },
       {
@@ -51,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "0e0d0aab665ff1a0659ce75ac003081f2b1c8997",
-          "version": "1.19.0"
+          "revision": "f1f6f772198bee35d99dd145f1513d8581a54f2c",
+          "version": "1.26.0"
         }
       },
       {
@@ -60,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "a8ccf13fa62775277a5d56844878c828bbb3be1a",
-          "version": "1.27.0"
+          "revision": "81cc18264f92cd307ff98430f89372711d4f6fe9",
+          "version": "1.43.0"
         }
       },
       {
@@ -78,8 +105,17 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "e7403c35ca6bb539a7ca353b91cc2d8ec0362d58",
-          "version": "1.19.0"
+          "revision": "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+          "version": "1.28.0"
+        }
+      },
+      {
+        "package": "swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics.git",
+        "state": {
+          "branch": null,
+          "revision": "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+          "version": "1.1.1"
         }
       },
       {
@@ -87,8 +123,17 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "0279688c9fc5a40028e1b5bb0cb56534a45a6020",
-          "version": "1.12.0"
+          "revision": "81558271e243f8f47dfe8e9fdd55f3c2b5413f68",
+          "version": "1.37.0"
+        }
+      },
+      {
+        "package": "swift-system",
+        "repositoryURL": "https://github.com/apple/swift-system.git",
+        "state": {
+          "branch": null,
+          "revision": "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+          "version": "1.6.4"
         }
       }
     ]


### PR DESCRIPTION
* Update all pinned dependencies in `Package.resolved`.
* Remove use of `setup-swift` and rely on toolchains pre-installed on GitHub Runners.
* Do not fail fast the test running matrix: we want to see all results of a single run.
* Move Slack notification to separate job after running tests.